### PR TITLE
ENG-715 - CVE-2024-28861 - Gadget Chain in Symfony 1 due to uncontrolled unserialized input

### DIFF
--- a/lib/util/sfNamespacedParameterHolder.class.php
+++ b/lib/util/sfNamespacedParameterHolder.class.php
@@ -45,6 +45,35 @@ class sfNamespacedParameterHolder extends sfParameterHolder
   }
 
   /**
+   * Serializes the current instance for PHP 7.4+.
+   *
+   * @return array
+   */
+  public function __serialize()
+  {
+    return [$this->default_namespace, $this->parameters];
+  }
+
+  /**
+   * Unserializes a sfParameterHolder instance for PHP 7.4+.
+   * [CVE-2024-28861] Check type of returned data to avoid deserialization vulnerabilities.
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+    if (!is_array($data) || 2 !== \count($data)) {
+      $this->default_namespace = null;
+      $this->parameters = [];
+
+      return;
+    }
+
+    $this->default_namespace = $data[0];
+    $this->parameters = $data[1];
+  }
+
+  /**
    * Sets the default namespace value.
    *
    * @param string $namespace  Default namespace
@@ -366,23 +395,20 @@ class sfNamespacedParameterHolder extends sfParameterHolder
   /**
    * Serializes the current instance.
    *
-   * @return array Objects instance
+   * @return string Objects instance
    */
   public function serialize()
   {
-    return serialize(array($this->default_namespace, $this->parameters));
+    return serialize($this->__serialize());
   }
 
   /**
    * Unserializes a sfNamespacedParameterHolder instance.
    *
-   * @param string $serialized  A serialized sfNamespacedParameterHolder instance
+   * @param string $serialized A serialized sfNamespacedParameterHolder instance
    */
   public function unserialize($serialized)
   {
-    $data = unserialize($serialized);
-
-    $this->default_namespace = $data[0];
-    $this->parameters = $data[1];
+    $this->__unserialize(unserialize($serialized));
   }
 }

--- a/lib/util/sfParameterHolder.class.php
+++ b/lib/util/sfParameterHolder.class.php
@@ -4,7 +4,7 @@
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
  * (c) 2004-2006 Sean Kerr <sean@code-box.org>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
@@ -30,6 +30,33 @@ class sfParameterHolder implements Serializable
    */
   public function __construct()
   {
+  }
+
+  /**
+   * Serializes the current instance for PHP 7.4+.
+   *
+   * @return array
+   */
+  public function __serialize()
+  {
+    return $this->parameters;
+  }
+
+  /**
+   * Unserializes a sfParameterHolder instance for PHP 7.4+.
+   * [CVE-2024-28861] Check type of returned data to avoid deserialization vulnerabilities.
+   *
+   * @param array $data
+   */
+  public function __unserialize($data)
+  {
+    if (!is_array($data)) {
+      $this->parameters = [];
+
+      return;
+    }
+
+    $this->parameters = $data;
   }
 
   /**
@@ -181,20 +208,20 @@ class sfParameterHolder implements Serializable
   /**
    * Serializes the current instance.
    *
-   * @return array Objects instance
+   * @return string Objects instance
    */
   public function serialize()
   {
-    return serialize($this->parameters);
+    return serialize($this->__serialize());
   }
 
   /**
    * Unserializes a sfParameterHolder instance.
    *
-   * @param string $serialized  A serialized sfParameterHolder instance
+   * @param string $serialized A serialized sfParameterHolder instance
    */
   public function unserialize($serialized)
   {
-    $this->parameters = unserialize($serialized);
+    $this->__unserialize(unserialize($serialized));
   }
 }

--- a/test/unit/util/sfNamespacedParameterHolderTest.php
+++ b/test/unit/util/sfNamespacedParameterHolderTest.php
@@ -3,14 +3,14 @@
 /*
  * This file is part of the symfony package.
  * (c) 2004-2006 Fabien Potencier <fabien.potencier@symfony-project.com>
- * 
+ *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(50);
+$t = new lime_test(51);
 
 // ->clear()
 $t->diag('->clear()');
@@ -213,3 +213,11 @@ $t->is($parameters, $ph->getAll(), '->add() adds a reference of an array of para
 // ->serialize() ->unserialize()
 $t->diag('->serialize() ->unserialize()');
 $t->ok($ph == unserialize(serialize($ph)), 'sfNamespacedParameterHolder implements the Serializable interface');
+
+// ->unserialize(JUST-A-STRING)
+$ph = new sfNamespacedParameterHolder('');
+$defaultPh = clone $ph;
+$ph->unserialize('FOO');
+
+$t->diag('->unserialize(JUST-A-STRING)');
+$t->ok($defaultPh == $ph, 'sfNamespacedParameterHolder CVE-2024-28861 fixed -- a non-serializable string');

--- a/test/unit/util/sfParameterHolderTest.php
+++ b/test/unit/util/sfParameterHolderTest.php
@@ -10,7 +10,7 @@
 
 require_once(__DIR__.'/../../bootstrap/unit.php');
 
-$t = new lime_test(28);
+$t = new lime_test(29);
 
 // ->clear()
 $t->diag('->clear()');
@@ -141,3 +141,11 @@ $t->is($parameters, $ph->getAll(), '->add() adds a reference of an array of para
 // ->serialize() ->unserialize()
 $t->diag('->serialize() ->unserialize()');
 $t->ok($ph == unserialize(serialize($ph)), 'sfParameterHolder implements the Serializable interface');
+
+// ->unserialize(JUST-A-STRING)
+$ph = new sfParameterHolder();
+$defaultPh = clone $ph;
+$ph->unserialize('FOO');
+
+$t->diag('->unserialize(JUST-A-STRING)');
+$t->ok($defaultPh == $ph, 'sfParameterHolder CVE-2024-28861 fixed -- a non-serializable string');


### PR DESCRIPTION
- Fix the security flow by manually applying hot fix (https://github.com/FriendsOfSymfony1/symfony1/commit/0bd9d59c69221f49bfc8be8b871b79e12d7d171a)
  - applied respective code blocks from `sfNamespacedParameterHolder`, `sfParameterHolder`
- Update tests